### PR TITLE
Bump minSdkVersion to 10 :(

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,5 +48,5 @@ ext.handheldVersionName="3.4.8"
 ext.handheldVersionCode=348
 ext.wearVersionName="1.0.0"
 ext.wearVersionCode=100
-ext.targetSdkVersion=27
+ext.targetSdkVersion=28
 ext.libnounoursVersion="2.0.1"

--- a/handheld/build.gradle
+++ b/handheld/build.gradle
@@ -6,7 +6,7 @@ android {
 
     defaultConfig {
         wearAppUnbundled true
-        minSdkVersion 3
+        minSdkVersion 10
         targetSdkVersion rootProject.targetSdkVersion
         versionName rootProject.handheldVersionName
         versionCode rootProject.handheldVersionCode

--- a/handheld/src/main/java/ca/rmen/nounours/android/handheld/AnimationSaveService.java
+++ b/handheld/src/main/java/ca/rmen/nounours/android/handheld/AnimationSaveService.java
@@ -29,7 +29,6 @@ import android.content.pm.PackageManager;
 import android.content.pm.ResolveInfo;
 import android.net.Uri;
 import android.os.Build;
-import android.support.v4.content.FileProvider;
 import android.util.Log;
 
 import java.io.File;
@@ -40,8 +39,8 @@ import ca.rmen.nounours.R;
 import ca.rmen.nounours.android.common.Constants;
 import ca.rmen.nounours.android.common.compat.ApiHelper;
 import ca.rmen.nounours.android.handheld.compat.NotificationCompat;
-import ca.rmen.nounours.data.Animation;
 import ca.rmen.nounours.android.handheld.util.AnimationUtil;
+import ca.rmen.nounours.data.Animation;
 
 /**
  * An {@link IntentService} subclass for handling asynchronous task requests in
@@ -155,7 +154,6 @@ public class AnimationSaveService extends IntentService {
         Uri uri = Uri.parse("content://" + BuildConfig.APPLICATION_ID + ".fileprovider/export/" + file.getName());
         sendIntent.putExtra(Intent.EXTRA_STREAM, uri);
         sendIntent.setType("image/gif");
-        sendIntent.setFlags(PendingIntent.FLAG_CANCEL_CURRENT);
         if (ApiHelper.getAPILevel() < Build.VERSION_CODES.ICE_CREAM_SANDWICH_MR1) {
             List<ResolveInfo> resInfoList = getPackageManager().queryIntentActivities(sendIntent, PackageManager.MATCH_DEFAULT_ONLY);
             for (ResolveInfo resolveInfo : resInfoList) {

--- a/handheld/src/main/java/ca/rmen/nounours/android/handheld/compat/Api26Helper.java
+++ b/handheld/src/main/java/ca/rmen/nounours/android/handheld/compat/Api26Helper.java
@@ -1,0 +1,60 @@
+/*
+ *   Copyright (c) 2009 - 2015 Carmen Alvarez
+ *
+ *   This file is part of Nounours for Android.
+ *
+ *   Nounours for Android is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation, either version 3 of the License, or
+ *   (at your option) any later version.
+ *
+ *   Nounours for Android is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with Nounours for Android.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package ca.rmen.nounours.android.handheld.compat;
+
+import android.annotation.TargetApi;
+import android.app.Notification;
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
+import android.app.PendingIntent;
+import android.content.Context;
+import android.graphics.drawable.Icon;
+
+import ca.rmen.nounours.R;
+
+@TargetApi(26)
+class Api26Helper {
+    private static final String CHANNEL_ID = "NOUNOURS";
+    private Api26Helper() {
+        // prevent instantiation
+    }
+
+    static Notification createNotification(Context context, int iconId, String tickerText, String contentText, int actionIconId, CharSequence actionText, PendingIntent pendingIntent) {
+        NotificationChannel channel = new NotificationChannel(CHANNEL_ID,
+                context.getString(R.string.app_name),
+                NotificationManager.IMPORTANCE_DEFAULT);
+        NotificationManager notificationManager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
+        notificationManager.createNotificationChannel(channel);
+
+        Notification.Builder builder = new Notification.Builder(context, CHANNEL_ID)
+                .setContentTitle(tickerText)
+                .setContentText(contentText)
+                .setSmallIcon(iconId)
+                .setContentIntent(pendingIntent);
+
+        if (actionIconId > 0) {
+            Icon icon = Icon.createWithResource(context, actionIconId);
+            Notification.Action action = new Notification.Action.Builder(icon, actionText, pendingIntent).build();
+            builder.addAction(action);
+        }
+        return builder.build();
+    }
+
+}

--- a/handheld/src/main/java/ca/rmen/nounours/android/handheld/compat/NotificationCompat.java
+++ b/handheld/src/main/java/ca/rmen/nounours/android/handheld/compat/NotificationCompat.java
@@ -70,8 +70,10 @@ public final class NotificationCompat {
             return Api11Helper.createNotification(context, iconId, tickerText, contentText, pendingIntent);
         } else if (ApiHelper.getAPILevel() < 23){
             return Api16Helper.createNotification(context, iconId, tickerText, contentText, actionIconId, actionText, pendingIntent);
-        } else {
+        } else if (ApiHelper.getAPILevel() < 26){
             return Api23Helper.createNotification(context, iconId, tickerText, contentText, actionIconId, actionText, pendingIntent);
+        } else {
+            return Api26Helper.createNotification(context, iconId, tickerText, contentText, actionIconId, actionText, pendingIntent);
         }
     }
 


### PR DESCRIPTION
If we use android gradle plugin 3.x, we won't even be able to install the apk on <= eclair devices: https://issuetracker.google.com/issues/111146570
I wasn't able to test this though, as I couldn't get any old emulators to start.

The oldest emulator I could get to start was a gingerbread, so I'm bumping the minSdk to that (10).

Add a notification channel for Oreo+ (or else it's not possible to share a recorded animation.