### PR TITLE
Fix security vulnerability with broadcasts

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,11 +42,11 @@ allprojects {
     }
 }
 
-ext.compileSdkVersion=28
+ext.compileSdkVersion=30
 ext.buildToolsVersion="28.0.3"
 ext.handheldVersionName="3.4.8"
 ext.handheldVersionCode=348
 ext.wearVersionName="3.4.9"
 ext.wearVersionCode=349
-ext.targetSdkVersion=28
+ext.targetSdkVersion=30
 ext.libnounoursVersion="2.0.1"

--- a/build.gradle
+++ b/build.gradle
@@ -44,8 +44,8 @@ allprojects {
 
 ext.compileSdkVersion=30
 ext.buildToolsVersion="28.0.3"
-ext.handheldVersionName="3.4.8"
-ext.handheldVersionCode=348
+ext.handheldVersionName="3.5.0"
+ext.handheldVersionCode=350
 ext.wearVersionName="3.4.9"
 ext.wearVersionCode=349
 ext.targetSdkVersion=30

--- a/handheld/build.gradle
+++ b/handheld/build.gradle
@@ -6,7 +6,7 @@ android {
 
     defaultConfig {
         wearAppUnbundled true
-        minSdkVersion 10
+        minSdkVersion 14
         targetSdkVersion rootProject.targetSdkVersion
         versionName rootProject.handheldVersionName
         versionCode rootProject.handheldVersionCode
@@ -77,5 +77,6 @@ android {
 dependencies {
     implementation "ca.rmen:libnounours:$libnounoursVersion"
     implementation 'com.robbypond:android-ColorPickerPreference:1.11.1'
+    implementation "androidx.localbroadcastmanager:localbroadcastmanager:1.0.0"
     implementation project(':common')
 }

--- a/handheld/src/main/AndroidManifest.xml
+++ b/handheld/src/main/AndroidManifest.xml
@@ -23,6 +23,7 @@
     <uses-sdk tools:overrideLibrary="net.margaritov.preference.colorpicker" />
 
     <uses-permission android:name="android.permission.VIBRATE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
 
     <uses-feature
         android:name="android.hardware.screen.portrait"

--- a/handheld/src/main/java/ca/rmen/nounours/android/handheld/AnimationSaveService.java
+++ b/handheld/src/main/java/ca/rmen/nounours/android/handheld/AnimationSaveService.java
@@ -57,7 +57,8 @@ public class AnimationSaveService extends IntentService {
 
     public static final String ACTION_SAVE_ANIMATION = "ca.rmen.nounours.action.SAVE_ANIMATION";
     public static final String EXTRA_SHARE_INTENT = "ca.rmen.nounours.extra.SHARE_INTENT";
-    public static final int NOTIFICATION_ID = TAG.hashCode();
+    public static final int SAVING_NOTIFICATION_ID = 56111176;
+    public static final int SAVED_NOTIFICATION_ID = 561135;
 
     private static final String EXTRA_ANIMATION = "ca.rmen.nounours.extra.ANIMATION";
 
@@ -102,7 +103,11 @@ public class AnimationSaveService extends IntentService {
         Notification notification = NotificationCompat.createNotification(this, iconId, R.string.notif_save_animation_in_progress_title, R.string.notif_save_animation_in_progress_content, getMainActivityIntent());
         notification.flags = Notification.FLAG_ONGOING_EVENT;
         NotificationManager notificationManager = (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
-        notificationManager.notify(NOTIFICATION_ID, notification);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            startForeground(SAVING_NOTIFICATION_ID, notification);
+        } else {
+            notificationManager.notify(SAVING_NOTIFICATION_ID, notification);
+        }
 
         // Save the file
         File file = AnimationUtil.saveAnimation(this, animation);
@@ -121,7 +126,7 @@ public class AnimationSaveService extends IntentService {
                     getString(R.string.share),
                     pendingShareIntent);
             notification.flags = Notification.FLAG_AUTO_CANCEL;
-            notificationManager.notify(NOTIFICATION_ID, notification);
+            notificationManager.notify(SAVED_NOTIFICATION_ID, notification);
             // Also broadcast that the save is done.
             Intent broadcastIntent = new Intent(ACTION_SAVE_ANIMATION);
             broadcastIntent.putExtra(EXTRA_SHARE_INTENT, shareIntent);
@@ -130,7 +135,7 @@ public class AnimationSaveService extends IntentService {
             // Notify that the save failed.
             notification = NotificationCompat.createNotification(this, iconId, R.string.notif_save_animation_failed, R.string.notif_save_animation_failed, getMainActivityIntent());
             notification.flags = Notification.FLAG_AUTO_CANCEL;
-            notificationManager.notify(NOTIFICATION_ID, notification);
+            notificationManager.notify(SAVED_NOTIFICATION_ID, notification);
         }
 
         Log.v(TAG, "end saving animation " + animation);

--- a/handheld/src/main/java/ca/rmen/nounours/android/handheld/AnimationSaveService.java
+++ b/handheld/src/main/java/ca/rmen/nounours/android/handheld/AnimationSaveService.java
@@ -31,6 +31,8 @@ import android.net.Uri;
 import android.os.Build;
 import android.util.Log;
 
+import androidx.localbroadcastmanager.content.LocalBroadcastManager;
+
 import java.io.File;
 import java.util.List;
 
@@ -123,7 +125,7 @@ public class AnimationSaveService extends IntentService {
             // Also broadcast that the save is done.
             Intent broadcastIntent = new Intent(ACTION_SAVE_ANIMATION);
             broadcastIntent.putExtra(EXTRA_SHARE_INTENT, shareIntent);
-            sendBroadcast(broadcastIntent);
+            LocalBroadcastManager.getInstance(this).sendBroadcast(broadcastIntent);
         } else {
             // Notify that the save failed.
             notification = NotificationCompat.createNotification(this, iconId, R.string.notif_save_animation_failed, R.string.notif_save_animation_failed, getMainActivityIntent());

--- a/handheld/src/main/java/ca/rmen/nounours/android/handheld/MainActivity.java
+++ b/handheld/src/main/java/ca/rmen/nounours/android/handheld/MainActivity.java
@@ -420,7 +420,7 @@ public class MainActivity extends Activity {
                 // file saving takes a long time, and the user leaves the activity in the middle
                 // of the saving.  In that case, the user will have to tap on the notification
                 // see the share app list.
-                notificationManager.cancel(AnimationSaveService.NOTIFICATION_ID);
+                notificationManager.cancel(AnimationSaveService.SAVED_NOTIFICATION_ID);
                 Intent shareIntent = intent.getParcelableExtra(AnimationSaveService.EXTRA_SHARE_INTENT);
                 startActivity(shareIntent);
             }

--- a/handheld/src/main/java/ca/rmen/nounours/android/handheld/MainActivity.java
+++ b/handheld/src/main/java/ca/rmen/nounours/android/handheld/MainActivity.java
@@ -43,6 +43,8 @@ import android.view.View;
 import android.widget.ImageButton;
 import android.widget.Toast;
 
+import androidx.localbroadcastmanager.content.LocalBroadcastManager;
+
 import java.util.Map;
 
 import ca.rmen.nounours.R;
@@ -190,7 +192,7 @@ public class MainActivity extends Activity {
             mSensorManager.registerListener(mSensorListener, mAccelerometerSensor, SensorManager.SENSOR_DELAY_NORMAL);
             mSensorManager.registerListener(mSensorListener, mMagneticFieldSensor, SensorManager.SENSOR_DELAY_NORMAL);
         }
-        registerReceiver(mBroadcastReceiver, new IntentFilter(AnimationSaveService.ACTION_SAVE_ANIMATION));
+        LocalBroadcastManager.getInstance(this).registerReceiver(mBroadcastReceiver, new IntentFilter(AnimationSaveService.ACTION_SAVE_ANIMATION));
     }
 
     /**
@@ -207,7 +209,7 @@ public class MainActivity extends Activity {
         if (mSensorManager != null) {
             mSensorManager.unregisterListener(mSensorListener);
         }
-        unregisterReceiver(mBroadcastReceiver);
+        LocalBroadcastManager.getInstance(this).unregisterReceiver(mBroadcastReceiver);
     }
 
 


### PR DESCRIPTION
https://support.google.com/faqs/answer/9267555

Scenario to reproduce the security vulnerability:
* Launch the app and stay in the main screen
* From another app, schedule (within 10 seconds for example) to launch the following:
    ```
    val intent = Intent("ca.rmen.nounours.action.SAVE_ANIMATION")
    intent.putExtra("ca.rmen.nounours.extra.SHARE_INTENT", Intent(Intent.ACTION_VIEW, Uri.parse("https://www.example.com")))
    sendBroadcast(intent)
    ```
* Go back to the this app (nounours/bugdroid buddy) before the 10 seconds
* Wait
* Expected behavior: nothing
* Actual behavior: the browser opens in https://www.example.com

---- 
Also:
We're required to update the target sdk to at least 29 to publish an update.

Update it to 30, and update the notifications of the IntentService, to use a foreground service during the file export.